### PR TITLE
Nextras Dbal 4.x + modern PHP

### DIFF
--- a/.github/workflows/codesniffer.yml
+++ b/.github/workflows/codesniffer.yml
@@ -14,4 +14,4 @@ jobs:
     name: "Codesniffer"
     uses: contributte/.github/.github/workflows/codesniffer.yml@v1
     with:
-      php: "8.0"
+      php: "8.2"

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -14,4 +14,4 @@ jobs:
     name: "Phpstan"
     uses: contributte/.github/.github/workflows/phpstan.yml@v1
     with:
-      php: "8.0"
+      php: "8.2"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,26 +10,20 @@ on:
     - cron: "0 8 * * 1"
 
 jobs:
-  build80:
+  build84:
     name: "Nette Tester"
     uses: contributte/.github/.github/workflows/nette-tester-mysql.yml@v1
     with:
-        php: "8.0"
+        php: "8.4"
 
-  build74:
+  build83:
     name: "Nette Tester"
     uses: contributte/.github/.github/workflows/nette-tester-mysql.yml@v1
     with:
-        php: "7.4"
+        php: "8.3"
 
-  build73:
+  build82:
     name: "Nette Tester"
     uses: contributte/.github/.github/workflows/nette-tester-mysql.yml@v1
     with:
-        php: "7.3"
-
-  build72:
-    name: "Nette Tester"
-    uses: contributte/.github/.github/workflows/nette-tester-mysql.yml@v1
-    with:
-        php: "7.2"
+        php: "8.2"

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     }
   ],
   "require": {
-    "php": ">=7.2",
+    "php": ">=8.1",
     "nextras/dbal": "^4.0.0"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     }
   ],
   "require": {
-    "php": ">=8.1",
+    "php": ">=8.2",
     "nextras/dbal": "^4.0.0"
   },
   "require-dev": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -6,11 +6,7 @@ includes:
 
 parameters:
 	level: 9
-	phpVersion: 80100
+	phpVersion: 80200
 	paths:
 		- src
-	scanDirectories:
-		- vendor/nette/di/src
-		- vendor/nextras/orm/src
-		- vendor/nextras/dbal/src
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -6,5 +6,11 @@ includes:
 
 parameters:
 	level: 9
-	phpVersion: 70200
+	phpVersion: 80100
+	paths:
+		- src
+	scanDirectories:
+		- vendor/nette/di/src
+		- vendor/nextras/orm/src
+		- vendor/nextras/dbal/src
 

--- a/src/DI/NextrasQueryObjectExtension.php
+++ b/src/DI/NextrasQueryObjectExtension.php
@@ -32,11 +32,11 @@ final class NextrasQueryObjectExtension extends CompilerExtension
 		$builder = $this->getContainerBuilder();
 
 		foreach ($builder->findByType(Repository::class) as $name => $def) {
-			$def->addTag(InjectExtension::TAG_INJECT);
+			$def->addTag(InjectExtension::TagInject);
 		}
 
 		foreach ($builder->findByType(Mapper::class) as $name => $def) {
-			$def->addTag(InjectExtension::TAG_INJECT);
+			$def->addTag(InjectExtension::TagInject);
 		}
 	}
 

--- a/tests/Cases/Exceptions.phpt
+++ b/tests/Cases/Exceptions.phpt
@@ -1,0 +1,37 @@
+<?php declare(strict_types = 1);
+
+use Contributte\Nextras\Orm\QueryObject\Exception\InvalidHydrationModeException;
+use Contributte\Nextras\Orm\QueryObject\Exception\InvalidObjectCreationException;
+use Tester\Assert;
+
+require_once __DIR__ . '/../bootstrap.php';
+
+// Test: InvalidHydrationModeException extends LogicException
+test(function (): void {
+	$exception = new InvalidHydrationModeException('Test message');
+
+	Assert::type(LogicException::class, $exception);
+	Assert::same('Test message', $exception->getMessage());
+});
+
+// Test: InvalidObjectCreationException extends LogicException
+test(function (): void {
+	$exception = new InvalidObjectCreationException('Creation failed');
+
+	Assert::type(LogicException::class, $exception);
+	Assert::same('Creation failed', $exception->getMessage());
+});
+
+// Test: InvalidHydrationModeException can be thrown and caught
+test(function (): void {
+	Assert::exception(function (): void {
+		throw new InvalidHydrationModeException('Invalid hydration mode "99"');
+	}, InvalidHydrationModeException::class, 'Invalid hydration mode "99"');
+});
+
+// Test: InvalidObjectCreationException can be thrown and caught
+test(function (): void {
+	Assert::exception(function (): void {
+		throw new InvalidObjectCreationException('Created object must be typed of QueryObject');
+	}, InvalidObjectCreationException::class, 'Created object must be typed of QueryObject');
+});

--- a/tests/Cases/ExecutableQueryObject.phpt
+++ b/tests/Cases/ExecutableQueryObject.phpt
@@ -1,0 +1,112 @@
+<?php declare(strict_types = 1);
+
+use Contributte\Nextras\Orm\QueryObject\ExecutableQueryObject;
+use Nextras\Dbal\Connection;
+use Nextras\Dbal\QueryBuilder\QueryBuilder;
+use Nextras\Dbal\Result\Result;
+use Tester\Assert;
+
+require_once __DIR__ . '/../bootstrap.php';
+
+/**
+ * Test ExecutableQueryObject
+ */
+class TestExecutableQueryObject extends ExecutableQueryObject
+{
+
+	public function doQuery(QueryBuilder $builder): QueryBuilder
+	{
+		return $builder->select('[*]')->from('[test_table]');
+	}
+
+}
+
+/**
+ * Test ExecutableQueryObject with custom postResult
+ */
+class TestExecutableQueryObjectWithPostResult extends ExecutableQueryObject
+{
+
+	private bool $postResultCalled = false;
+
+	public function doQuery(QueryBuilder $builder): QueryBuilder
+	{
+		return $builder->select('[id]')->from('[users]');
+	}
+
+	public function postResult(Result $result): Result
+	{
+		$this->postResultCalled = true;
+		return parent::postResult($result);
+	}
+
+	public function wasPostResultCalled(): bool
+	{
+		return $this->postResultCalled;
+	}
+
+}
+
+// Test: ExecutableQueryObject builds query via fetch method
+test(function (): void {
+	$connection = Mockery::mock(Connection::class);
+	$queryBuilder = Mockery::mock(QueryBuilder::class);
+
+	$queryBuilder->shouldReceive('select')
+		->with('[*]')
+		->once()
+		->andReturnSelf();
+
+	$queryBuilder->shouldReceive('from')
+		->with('[test_table]')
+		->once()
+		->andReturnSelf();
+
+	$qo = new TestExecutableQueryObject($connection);
+	$result = $qo->fetch($queryBuilder);
+
+	Assert::type(QueryBuilder::class, $result);
+
+	Mockery::close();
+});
+
+// Test: ExecutableQueryObject execute method uses connection
+test(function (): void {
+	$connection = Mockery::mock(Connection::class);
+	$queryBuilder = Mockery::mock(QueryBuilder::class);
+	$result = Mockery::mock(Result::class);
+
+	$queryBuilder->shouldReceive('select')
+		->with('[*]')
+		->once()
+		->andReturnSelf();
+
+	$queryBuilder->shouldReceive('from')
+		->with('[test_table]')
+		->once()
+		->andReturnSelf();
+
+	$queryBuilder->shouldReceive('getQuerySql')
+		->once()
+		->andReturn('SELECT * FROM test_table');
+
+	$queryBuilder->shouldReceive('getQueryParameters')
+		->once()
+		->andReturn([]);
+
+	$connection->shouldReceive('createQueryBuilder')
+		->once()
+		->andReturn($queryBuilder);
+
+	$connection->shouldReceive('queryArgs')
+		->with('SELECT * FROM test_table', [])
+		->once()
+		->andReturn($result);
+
+	$qo = new TestExecutableQueryObject($connection);
+	$executeResult = $qo->execute();
+
+	Assert::type(Result::class, $executeResult);
+
+	Mockery::close();
+});

--- a/tests/Cases/QueryObjectContextAwareManager.phpt
+++ b/tests/Cases/QueryObjectContextAwareManager.phpt
@@ -1,0 +1,99 @@
+<?php declare(strict_types = 1);
+
+use Contributte\Nextras\Orm\QueryObject\Exception\InvalidObjectCreationException;
+use Contributte\Nextras\Orm\QueryObject\QueryObject;
+use Contributte\Nextras\Orm\QueryObject\QueryObjectContextAwareManager;
+use Nette\DI\Container;
+use Nextras\Dbal\Connection;
+use Nextras\Dbal\QueryBuilder\QueryBuilder;
+use Nextras\Dbal\Result\Result;
+use Tester\Assert;
+use Tests\Mocks\SimpleQueryObject;
+
+require_once __DIR__ . '/../bootstrap.php';
+
+// Test: QueryObjectContextAwareManager create returns QueryObject
+test(function (): void {
+	$queryObject = new SimpleQueryObject();
+
+	$container = Mockery::mock(Container::class);
+	$container->shouldReceive('getByType')
+		->with(SimpleQueryObject::class)
+		->once()
+		->andReturn($queryObject);
+
+	$manager = new QueryObjectContextAwareManager($container);
+	$result = $manager->create(SimpleQueryObject::class);
+
+	Assert::type(QueryObject::class, $result);
+	Assert::same($queryObject, $result);
+
+	Mockery::close();
+});
+
+// Test: QueryObjectContextAwareManager create throws InvalidObjectCreationException for non-QueryObject
+test(function (): void {
+	$nonQueryObject = new stdClass();
+
+	$container = Mockery::mock(Container::class);
+	$container->shouldReceive('getByType')
+		->with(stdClass::class)
+		->once()
+		->andReturn($nonQueryObject);
+
+	$manager = new QueryObjectContextAwareManager($container);
+
+	Assert::exception(function () use ($manager): void {
+		$manager->create(stdClass::class);
+	}, InvalidObjectCreationException::class);
+
+	Mockery::close();
+});
+
+// Test: QueryObjectContextAwareManager fetch returns Result
+test(function (): void {
+	$connection = Mockery::mock(Connection::class);
+	$queryBuilder = Mockery::mock(QueryBuilder::class);
+	$result = Mockery::mock(Result::class);
+
+	$queryBuilder->shouldReceive('select')
+		->with('[*]')
+		->once()
+		->andReturnSelf();
+
+	$queryBuilder->shouldReceive('from')
+		->with('[foobar]')
+		->once()
+		->andReturnSelf();
+
+	$queryBuilder->shouldReceive('getQuerySql')
+		->once()
+		->andReturn('SELECT * FROM foobar');
+
+	$queryBuilder->shouldReceive('getQueryParameters')
+		->once()
+		->andReturn([]);
+
+	$connection->shouldReceive('createQueryBuilder')
+		->once()
+		->andReturn($queryBuilder);
+
+	$connection->shouldReceive('queryArgs')
+		->with('SELECT * FROM foobar', [])
+		->once()
+		->andReturn($result);
+
+	$container = Mockery::mock(Container::class);
+	$container->shouldReceive('getByType')
+		->with(Connection::class)
+		->once()
+		->andReturn($connection);
+
+	$manager = new QueryObjectContextAwareManager($container);
+	$queryObject = new SimpleQueryObject();
+	$fetchResult = $manager->fetch($queryObject);
+
+	Assert::type(Result::class, $fetchResult);
+
+	Mockery::close();
+});

--- a/tests/Cases/Queryable.phpt
+++ b/tests/Cases/Queryable.phpt
@@ -1,0 +1,16 @@
+<?php declare(strict_types = 1);
+
+use Contributte\Nextras\Orm\QueryObject\Queryable;
+use Tester\Assert;
+
+require_once __DIR__ . '/../bootstrap.php';
+
+// Test: Queryable interface defines HYDRATION_RESULTSET constant
+test(function (): void {
+	Assert::same(1, Queryable::HYDRATION_RESULTSET);
+});
+
+// Test: Queryable interface defines HYDRATION_ENTITY constant
+test(function (): void {
+	Assert::same(2, Queryable::HYDRATION_ENTITY);
+});

--- a/tests/Cases/TRepositoryQueryable.phpt
+++ b/tests/Cases/TRepositoryQueryable.phpt
@@ -1,0 +1,162 @@
+<?php declare(strict_types = 1);
+
+use Contributte\Nextras\Orm\QueryObject\Exception\InvalidHydrationModeException;
+use Contributte\Nextras\Orm\QueryObject\Queryable;
+use Contributte\Nextras\Orm\QueryObject\Repository\TRepositoryQueryable;
+use Nextras\Dbal\Connection;
+use Nextras\Dbal\QueryBuilder\QueryBuilder;
+use Nextras\Dbal\Result\Result;
+use Nextras\Orm\Collection\ICollection;
+use Nextras\Orm\Mapper\Mapper;
+use Tester\Assert;
+use Tests\Mocks\SimpleQueryObject;
+
+require_once __DIR__ . '/../bootstrap.php';
+
+/**
+ * Test class that uses TRepositoryQueryable trait
+ */
+class TestRepository
+{
+
+	use TRepositoryQueryable;
+
+	/** @var Mapper */
+	public $mapper;
+
+}
+
+// Test: TRepositoryQueryable injectConnection stores connection
+test(function (): void {
+	$connection = Mockery::mock(Connection::class);
+
+	$repo = new TestRepository();
+	$repo->injectConnection($connection);
+
+	// Using reflection to verify connection was stored
+	$reflection = new ReflectionClass($repo);
+	$property = $reflection->getProperty('connection');
+	$property->setAccessible(true);
+
+	Assert::same($connection, $property->getValue($repo));
+
+	Mockery::close();
+});
+
+// Test: TRepositoryQueryable fetch with HYDRATION_RESULTSET returns Result
+test(function (): void {
+	$connection = Mockery::mock(Connection::class);
+	$queryBuilder = Mockery::mock(QueryBuilder::class);
+	$result = Mockery::mock(Result::class);
+
+	$queryBuilder->shouldReceive('select')
+		->with('[*]')
+		->once()
+		->andReturnSelf();
+
+	$queryBuilder->shouldReceive('from')
+		->with('[foobar]')
+		->once()
+		->andReturnSelf();
+
+	$queryBuilder->shouldReceive('getQuerySql')
+		->once()
+		->andReturn('SELECT * FROM foobar');
+
+	$queryBuilder->shouldReceive('getQueryParameters')
+		->once()
+		->andReturn([]);
+
+	$connection->shouldReceive('createQueryBuilder')
+		->once()
+		->andReturn($queryBuilder);
+
+	$connection->shouldReceive('queryArgs')
+		->with('SELECT * FROM foobar', [])
+		->once()
+		->andReturn($result);
+
+	$repo = new TestRepository();
+	$repo->injectConnection($connection);
+
+	$queryObject = new SimpleQueryObject();
+	$fetchResult = $repo->fetch($queryObject, Queryable::HYDRATION_RESULTSET);
+
+	Assert::type(Result::class, $fetchResult);
+
+	Mockery::close();
+});
+
+// Test: TRepositoryQueryable fetch with HYDRATION_ENTITY returns ICollection
+test(function (): void {
+	$connection = Mockery::mock(Connection::class);
+	$queryBuilder = Mockery::mock(QueryBuilder::class);
+	$mapper = Mockery::mock(Mapper::class);
+
+	// Suppress deprecation warnings from ICollection (PHP 8.4 issue with implicit nullable params)
+	$previousErrorReporting = error_reporting();
+	error_reporting($previousErrorReporting & ~E_DEPRECATED);
+	$collection = Mockery::mock(ICollection::class);
+	error_reporting($previousErrorReporting);
+
+	$queryBuilder->shouldReceive('select')
+		->with('[*]')
+		->once()
+		->andReturnSelf();
+
+	$queryBuilder->shouldReceive('from')
+		->with('[foobar]')
+		->once()
+		->andReturnSelf();
+
+	$connection->shouldReceive('createQueryBuilder')
+		->once()
+		->andReturn($queryBuilder);
+
+	$mapper->shouldReceive('toCollection')
+		->with($queryBuilder)
+		->once()
+		->andReturn($collection);
+
+	$repo = new TestRepository();
+	$repo->injectConnection($connection);
+	$repo->mapper = $mapper;
+
+	$queryObject = new SimpleQueryObject();
+	$fetchResult = $repo->fetch($queryObject, Queryable::HYDRATION_ENTITY);
+
+	Assert::type(ICollection::class, $fetchResult);
+
+	Mockery::close();
+});
+
+// Test: TRepositoryQueryable fetch throws InvalidHydrationModeException for invalid mode
+test(function (): void {
+	$connection = Mockery::mock(Connection::class);
+	$queryBuilder = Mockery::mock(QueryBuilder::class);
+
+	$queryBuilder->shouldReceive('select')
+		->with('[*]')
+		->once()
+		->andReturnSelf();
+
+	$queryBuilder->shouldReceive('from')
+		->with('[foobar]')
+		->once()
+		->andReturnSelf();
+
+	$connection->shouldReceive('createQueryBuilder')
+		->once()
+		->andReturn($queryBuilder);
+
+	$repo = new TestRepository();
+	$repo->injectConnection($connection);
+
+	$queryObject = new SimpleQueryObject();
+
+	Assert::exception(function () use ($repo, $queryObject): void {
+		$repo->fetch($queryObject, 999);
+	}, InvalidHydrationModeException::class, 'Invalid hydration mode "999"');
+
+	Mockery::close();
+});

--- a/tests/php.ini
+++ b/tests/php.ini
@@ -1,4 +1,0 @@
-; Test environment configuration
-extension=ctype
-extension=tokenizer
-memory_limit=256M

--- a/tests/php.ini
+++ b/tests/php.ini
@@ -1,0 +1,4 @@
+; Test environment configuration
+extension=ctype
+extension=tokenizer
+memory_limit=256M


### PR DESCRIPTION
- Update PHP requirement to >=8.1 (required by nette/di 3.x)
- Fix deprecated TAG_INJECT constant (now TagInject)
- Update PHPStan configuration for proper analysis
- Add comprehensive test coverage for QueryObject, ExecutableQueryObject, QueryObjectContextAwareManager, TRepositoryQueryable, and exceptions